### PR TITLE
讓 prepare.py 可以指定 csv 檔案位置

### DIFF
--- a/prepare.py
+++ b/prepare.py
@@ -101,10 +101,9 @@ def inRange(point):
         pass
     return (point, None)
 
-def preparing(opath = "./cctv_imgs", token = "nfbCCTV-N1-N-90.01-M", dest = "./datasets", isTest=False):
+def preparing(csv_fn = "./cctvid-vd-dest-cctv_url.csv", opath = "./cctv_imgs", token = "nfbCCTV-N1-N-90.01-M", dest = "./datasets", isTest=False):
     global lots
     DIR = "%s/%s"%(opath, token)
-    csv_fn = "./cctvid-vd-dest-cctv_url.csv"
 
     # get vdid info.
     try:
@@ -262,6 +261,9 @@ def main():
     parser.add_option('-d', '--datasets_path', dest='datasets_path',
             default="./datasets",
             help='destination path for pickled(dill) datasets, default="./datasets"')
+    parser.add_option('-f', '--csv_file', dest='file',
+	            default="cctvid-vd-dest-cctv_url.csv",
+	            help="read csv file for current cctvid-vd-dest-cctv_url information, default=cctvid-vd-dest-cctv_url.csv")
     parser.add_option('-c', '--cctvid', dest='cctvid',
             default="nfbCCTV-N1-N-90.01-M",
             help='preparing datasets for "nfbCCTV-N1-N-90.01-M", default="nfbCCTV-N1-N-90.01-M"')
@@ -273,7 +275,7 @@ def main():
 
     logging.basicConfig(level=logging.INFO)
 
-    preparing(options.img_path, options.cctvid, options.datasets_path, options.isTest)
+    preparing(options.file,options.img_path, options.cctvid, options.datasets_path, options.isTest)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
在 `feed.py` 中，可以指定 `cctvid-vd-dest-cctv_url.csv` 的位置
不過 `prepare.py` 直接預設 `cctvid-vd-dest-cctv_url.csv` 檔案位置

這裡直接用 `feed.py` 的相關段落來調整 `prepare.py`
希望可以讓 `prepare.py` 也能指定 `cctvid-vd-dest-cctv_url.csv` 的位置

謝謝